### PR TITLE
fix: unittests were allowed to fail

### DIFF
--- a/.github/workflows/unit-test-and-reporting.yml
+++ b/.github/workflows/unit-test-and-reporting.yml
@@ -25,7 +25,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install coverage
     - name: Run Tests and Coverage
-      continue-on-error: true
+      continue-on-error: false
       run: |
         python -m coverage run --source pyshamir -m unittest discover -p test_*.py
         python -m coverage xml


### PR DESCRIPTION
### Context
It was observed that when the unittests would fail, GitHub workflow stage would continue on error.

### Changelog
disabled continue on error