### PR TITLE
Removing generic type hints to support Python version < 3.9

### DIFF
--- a/pyshamir/shamir.py
+++ b/pyshamir/shamir.py
@@ -1,7 +1,7 @@
 import secrets
 from ._utils import make_polynomial, interpolate_polynomial, generate_x_coordinates
 
-def combine(parts: list[bytearray]) -> bytearray:
+def combine(parts: list) -> bytearray:
     """
     Takes a list of parts and returns the secret
     :param parts:
@@ -53,7 +53,7 @@ def combine(parts: list[bytearray]) -> bytearray:
 
     return secret
 
-def split(secret: bytes, parts: int, threshold: int) -> list[bytearray]:
+def split(secret: bytes, parts: int, threshold: int) -> list:
     """
     Takes a secret and splits it into parts
     :param secret:


### PR DESCRIPTION
Removed the generic type hints and tested it on Python 3.8 interpreter.