### PR TITLE
chore: change python version for unit testing to 3.7

### DIFF
--- a/.github/workflows/unit-test-and-reporting.yml
+++ b/.github/workflows/unit-test-and-reporting.yml
@@ -16,10 +16,10 @@ jobs:
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
-    - name: Set up Python 3.9
+    - name: Set up Python 3.7
       uses: actions/setup-python@v2
       with:
-        python-version: 3.9
+        python-version: 3.7
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -40,4 +40,3 @@ jobs:
           -Dsonar.organization=konidev20
           -Dsonar.python.coverage.reportPaths=coverage.xml
           -Dsonar.sources=pyshamir
-


### PR DESCRIPTION
Pyshamir has support for Python version >= 3.7. Running unit tests and builds on the lowest supported version makes more sense to avoid errors.