### PR TITLE
chore: bump version from v1.0.3 to v1.0.4

### DIFF
--- a/pyshamir/__init__.py
+++ b/pyshamir/__init__.py
@@ -1,3 +1,3 @@
 from .shamir import combine, split
 
-__version__ = "1.0.3"
+__version__ = "1.0.4"


### PR DESCRIPTION
upgrading version from v1.0.3 to v1.0.4 with the new MPLv2.0 license.