### PR TITLE
fix: create release-please releases as drafts to allow asset upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,9 +12,12 @@
 #      branch protection's required-PR-review on main).
 #   4. The next push to main (the merge commit) re-runs release-please, which
 #      sees the merged Release PR, creates the vX.Y.Z tag, and creates the
-#      GitHub release.
+#      GitHub release as a *draft* (so we can attach signed assets before the
+#      release becomes immutable on publish).
 #   5. The build / publish / sign-and-attach jobs run only when
 #      release_created == true (i.e. on the post-merge run that cuts the tag).
+#      The sign-and-attach job uploads sdist+wheel+sigstore bundles and then
+#      flips the release out of draft state, publishing it.
 #
 # To force a specific version (e.g. a pre-release or skipping ahead):
 #   add `Release-As: 1.1.0-rc1` to the commit body of any commit on main.
@@ -128,10 +131,18 @@ jobs:
         with:
           inputs: ./dist/*.tar.gz ./dist/*.whl
 
-      - name: Upload signed assets to the GitHub release
+      - name: Upload signed assets to the draft GitHub release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release upload "${{ needs.release-please.outputs.tag_name }}" \
             dist/*.tar.gz dist/*.whl dist/*.sigstore.json \
+            --repo "${{ github.repository }}"
+
+      - name: Publish the GitHub release (exits draft state)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release edit "${{ needs.release-please.outputs.tag_name }}" \
+            --draft=false \
             --repo "${{ github.repository }}"

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,7 +6,7 @@
       "package-name": "pyshamir",
       "include-component-in-tag": false,
       "include-v-in-tag": true,
-      "draft": false,
+      "draft": true,
       "prerelease": false,
       "bump-minor-pre-major": false,
       "bump-patch-for-minor-pre-major": false,


### PR DESCRIPTION
## Summary
- Fixes the v1.0.5 release failure ([run 25605871213](https://github.com/konidev20/pyshamir/actions/runs/25605871213)) where `Sign and attach release assets` failed with `HTTP 422: Cannot upload assets to an immutable release.`
- **Root cause**: release-please was creating the GitHub release as already-published, and GitHub locks non-draft releases as immutable. By the time the workflow tried to attach signed sdist + wheel + Sigstore bundles, the release could no longer accept new assets.
- **Fix**: switch to `"draft": true` in `release-please-config.json`. The release is created as a draft (still mutable); the sign-and-attach job uploads assets to the draft; then a new `Publish the GitHub release` step flips it out of draft state. Once published the release is immutable, but by then it has the assets we wanted.
- **Parallel fix already applied** (settings only): the `pypi` GitHub environment's deployment-branch-policies were updated to include `main`, which fixes the matching `Publish to PyPI via OIDC` rejection (`Branch "main" is not allowed to deploy to pypi`).
- The `Release-As: 1.0.6` footer skips the broken v1.0.5 release and ships v1.0.6 with the actual signed artifacts and PyPI publish. The empty v1.0.5 GitHub release stays as a placeholder (no PyPI version was ever published for v1.0.5, so no version conflict).

## Test plan
- [x] Merge this PR.
- [ ] Verify release-please opens a Release PR titled `chore(main): release 1.0.6`.
- [ ] Approve and merge the Release PR.
- [ ] Verify the post-merge workflow run:
  - [ ] creates the `v1.0.6` tag and a GitHub release in **draft** state
  - [ ] publishes to PyPI via OIDC (no environment-policy rejection)
  - [ ] uploads signed sdist + wheel + Sigstore bundles to the draft
  - [ ] flips the release out of draft (final state: published, immutable, with all signed assets attached)
- [ ] Confirm `pip install pyshamir==1.0.6` works after the release lands.

Generated with [Claude Code](https://claude.com/claude-code)
